### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Astronomer.io
-      uses: elgohr/Publish-Docker-Github-Action@2.6
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: geocentric-fusion-4341/airflow:ci-${{ github.sha }}
         username: _


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore